### PR TITLE
improvement(validations): added username and password validations

### DIFF
--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -9,7 +9,7 @@
   "platform": "android",
   "author_name": "Juan Hernandez",
   "author_email": "j.hernandez@applicaster.com",
-  "manifest_version": "0.1.2",
+  "manifest_version": "0.1.3",
   "name": "AWSCognitoLogin",
   "description": "Plugin to connect AWS Login services to our apps",
   "type": "login",
@@ -17,7 +17,7 @@
   "identifier": "AWSCognitoLogin",
   "ui_builder_support": true,
   "dependency_name": "com.applicaster:AWSCognitoLogin-Android",
-  "dependency_version": "0.1.2",
+  "dependency_version": "0.1.3",
   "whitelisted_account_ids": [
     "5bb621649adec2000c289f22",
     "5c47af22291767000c8c9065"
@@ -305,6 +305,11 @@
       {
       "key": "awsco_update_pwd_btn_txt",
       "tooltip_text": "Update Password Update Button Text",
+      "type": "text"
+      },
+      {
+      "key": "awsco_password_error_message",
+      "tooltip_text": "Error message when password doesn't meet requirements",
       "type": "text"
       }
   ]

--- a/src/main/java/com/applicaster/awscognitologin/screens/signin/SignInActivity.kt
+++ b/src/main/java/com/applicaster/awscognitologin/screens/signin/SignInActivity.kt
@@ -107,6 +107,11 @@ class SignInActivity : AWSActivity(), SignInView, View.OnClickListener {
                 .show()
     }
 
+    override fun onBackPressed() {
+        super.onBackPressed()
+        LoginManager.notifyEvent(this, LoginManager.RequestType.LOGIN, false)
+    }
+
     override fun showProgress() {
         l_progress.visibility = View.VISIBLE
     }

--- a/src/main/java/com/applicaster/awscognitologin/screens/signup/SignUpActivity.kt
+++ b/src/main/java/com/applicaster/awscognitologin/screens/signup/SignUpActivity.kt
@@ -9,6 +9,7 @@ import android.support.v7.app.AppCompatActivity
 import android.util.Patterns
 import android.view.View
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.CognitoUserCodeDeliveryDetails
+import com.amazonaws.services.cognitoidentityprovider.model.UsernameExistsException
 import com.applicaster.awscognitologin.R
 import com.applicaster.awscognitologin.plugin.PluginDataRepository
 import com.applicaster.awscognitologin.screens.activate.ActivateAccountActivity
@@ -18,6 +19,7 @@ import com.applicaster.awscognitologin.utils.UIUtils
 import com.applicaster.plugin_manager.login.LoginManager
 import com.applicaster.util.ui.Toaster
 import kotlinx.android.synthetic.main.activity_sign_up.*
+import java.security.InvalidParameterException
 
 class SignUpActivity : AWSActivity(), SignUpView, View.OnClickListener {
 
@@ -93,6 +95,13 @@ class SignUpActivity : AWSActivity(), SignUpView, View.OnClickListener {
                     return
                 }
 
+                if(!UIUtils.checkIfUsernameMatchesPattern(et_username_su.text.toString())) {
+                    UIUtils.getAlertDialog(this, this.getString(R.string.on_sign_up_failed_title),
+                            this.getString(R.string.on_username_failed_pattern), this.getString(R.string.ok_btn))
+                            .show()
+                    return
+                }
+
                 hideView(tv_confirm_password_validation_su)
 
                 signUpPresenter.signUp(et_username_su.text.toString(),
@@ -138,9 +147,15 @@ class SignUpActivity : AWSActivity(), SignUpView, View.OnClickListener {
     }
 
     override fun onSignUpFailed(exception: Exception) {
-        // todo: value password policies and show user what they are
+        val errorMessage =
+                when (exception) {
+                    is InvalidParameterException -> UIUtils.getPasswordFailMessage(this)
+                    is UsernameExistsException -> this.getString(R.string.on_sign_up_failed_username_doesnt_exists)
+                    else -> this.getString(R.string.on_sign_up_failed_message)
+                }
+
         UIUtils.getAlertDialog(this, this.getString(R.string.on_sign_up_failed_title),
-                this.getString(R.string.on_sign_up_failed_message), this.getString(R.string.ok_btn))
+                errorMessage, this.getString(R.string.ok_btn))
                 .show()
     }
 

--- a/src/main/java/com/applicaster/awscognitologin/utils/UIUtils.kt
+++ b/src/main/java/com/applicaster/awscognitologin/utils/UIUtils.kt
@@ -13,8 +13,11 @@ import android.widget.*
 import com.applicaster.awscognitologin.R
 import com.applicaster.awscognitologin.plugin.PluginDataRepository
 import com.applicaster.awscognitologin.screens.signin.SignInActivity
+import com.applicaster.util.StringUtil
 import com.rengwuxian.materialedittext.MaterialEditText
 import kotlinx.android.synthetic.main.activity_sign_in.*
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 
 class UIUtils {
     companion object {
@@ -102,6 +105,15 @@ class UIUtils {
             }
         }
 
+        fun getPasswordFailMessage(context: Context): String {
+            params?.let {
+                val message = params["awsco_password_error_message"].toString()
+                return if (message != "null") message else context.getString(R.string.on_sign_up_failed_message)
+            }
+
+            return context.getString(R.string.on_sign_up_failed_message)
+        }
+
         fun getAlertDialog(context: Context, title: String, message: String,
                            positiveBtnText: String)
                 : AlertDialog {
@@ -140,6 +152,13 @@ class UIUtils {
                 }
 
             })
+        }
+
+        fun checkIfUsernameMatchesPattern(string: String): Boolean {
+            val patternStr = "^(?=.{8,20}\$)(?![_.])(?!.*[_.]{2})[a-zA-Z0-9._]+(?<![_.])\$"
+            val pattern: Pattern = Pattern.compile(patternStr)
+            val matcher: Matcher = pattern.matcher(string)
+            return matcher.matches()
         }
     }
 }

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -43,4 +43,6 @@
     <string name="on_sign_in_failed_message">Hubo un error entrando en su cuenta. Por favor, chequee sus credenciales y trate de nuevo.</string>
     <string name="on_sign_up_failed_title">Registro fallado</string>
     <string name="on_sign_up_failed_message">Hubo un error creando su cuenta. Por favor, chequee si su contraseña cumple con los requerimientos del website.</string>
+    <string name="on_username_failed_pattern">El usuario no es valido. Por favor elige otro.</string>
+    <string name="on_sign_up_failed_username_doesnt_exists">El nombre de usuario entrado ya existe.</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -43,4 +43,6 @@
     <string name="on_sign_in_failed_message">There was an error signing in. Please check your username and password and try again.</string>
     <string name="on_sign_up_failed_title">Sign Up Failed</string>
     <string name="on_sign_up_failed_message">There was an error signing you up. Please, check if your password complies with our website.</string>
+    <string name="on_username_failed_pattern">Username is not valid. Please choose another.</string>
+    <string name="on_sign_up_failed_username_doesnt_exists">Username exists already.</string>
 </resources>


### PR DESCRIPTION
In order to let the user know what type of error he got we use `InvalidParameterException` and `UsernameExistsException`.
To check if the username was valid we needed to implement this locally because when we send an invalid username, AWS Cognito API returned `InvalidParameterException`, the same exception when the password was invalid.
Now, the client is able to set a custom message to show the user when the password is not valid. For example, the client can put something like
```
The password is not valid. It needs to have at least 6 characters, one capital letter, etc...
```

**Bonus change**:
When the user hits back in the login screen, we let the app know that the login was not successful (the user canceled).